### PR TITLE
Replace unsafe gets function with fgets

### DIFF
--- a/BNCS.c
+++ b/BNCS.c
@@ -258,11 +258,11 @@ int elevenuptodec(int sb,int tb)
     fflush(stdin);
     printf("\ninformation :");
     
-    gets(s);
+    fgets(s, sizeof(s), stdin);
     //scanf("%c",&s[i]);
     if(sb==16)
     {
-        for(i=0;s[i]!=NULL;i++)
+        for(i=0;s[i]!=NULL && s[i] != '\n';i++)
         {
             switch(s[i])
             {


### PR DESCRIPTION
To reproduce, enter 11 as source system, 10 as target system, and 111111111111111111111111111111 as information.

This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).